### PR TITLE
Remove hard-coded datasource selections

### DIFF
--- a/app/Application.cfc
+++ b/app/Application.cfc
@@ -1,6 +1,20 @@
 <cfcomponent output="false">
 
-  <cfquery result="result" name="findit" datasource="abo">
+  <cfset host=ListFirst(cgi.server_name, ".")/>
+
+  <Cfset application.dbug = "Y" />
+
+    <cfif host is "app">
+        <cfset application.dsn="abo"/>
+        <cfset application.information_schema="actorsbusinessoffice"/>
+        <cfset application.suffix="_1.5"/>
+    <cfelse>
+        <cfset application.dsn="abod"/>
+        <cfset application.information_schema="actorsbusinessoffice"/>
+        <cfset application.suffix="_1.5"/>
+    </cfif>
+
+  <cfquery result="result" name="findit" datasource="#application.dsn#">
     SELECT verid
     FROM taoversions
     ORDER BY isactive DESC, verid DESC
@@ -8,23 +22,6 @@
   </cfquery>
 
   <cfset current_ver=findit.verid/>
-
-  <cfset host=ListFirst(cgi.server_name, ".")/>
-
-  <Cfset application.dbug = "Y" />
-  
-
-    <cfif #host# is "app">
-        <cfset application.dsn="abo"/>
-    <cfset application.information_schema="actorsbusinessoffice"/>
-    <cfset application.suffix="_1.5"/>
-        <cfelse>
-            
-          <cfset application.dsn="abod"/>
-    <cfset application.information_schema="actorsbusinessoffice"/>
-    <cfset application.suffix="_1.5"/>
-                
-    </cfif>
     
 
     <cfset application.rev=current_ver />

--- a/app/assets/js/autolookupbackup.cfm
+++ b/app/assets/js/autolookupbackup.cfm
@@ -1,14 +1,6 @@
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-    <cfset rev = "1.2.0" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
 
 <cfquery result="result"  name="jsons">
             SELECT col1 from contacts_ss WHERE userid = #userid# and col1 not like '%#chr(34)#%'

--- a/app/insert_files.cfm
+++ b/app/insert_files.cfm
@@ -14,7 +14,7 @@
 
     <!--- Try to insert each file into the database --->
     <cftry>
-        <cfquery result="result" datasource="abod">
+        <cfquery result="result" datasource="#application.dsn#">
             INSERT INTO tao_files (`filename`, `status`, `path`, `updated_timestamp`)
             VALUES (
                 <cfqueryparam value="#fname#" cfsqltype="cf_sql_varchar" maxlength="255">,
@@ -38,7 +38,7 @@
     <cfset fname = listLast(f, "/")>
 
     <cftry>
-        <cfquery result="result" datasource="abod">
+        <cfquery result="result" datasource="#application.dsn#">
             INSERT INTO tao_files (`filename`, `status`, `path`, `updated_timestamp`)
             VALUES (
                 <cfqueryparam value="#fname#" cfsqltype="cf_sql_varchar" maxlength="255">,

--- a/app/myaccount/update_newsletter.cfm
+++ b/app/myaccount/update_newsletter.cfm
@@ -1,15 +1,7 @@
  
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-    <cfset rev = "1.2.0" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
 
 <cfquery result="result"  name="update">
         update taousers

--- a/auth-recoverpw.cfm
+++ b/auth-recoverpw.cfm
@@ -1,18 +1,9 @@
 <cfapplication name="TAO" sessionmanagement="true">
 
-<cfset currentURL = cgi.server_name />
-<cfset host = ListFirst(currentURL, ".") />
-
-<!--- Determine the datasource and schema based on the host --->
-<cfif host is "app">
-    <cfset dsn = "abo" />
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-<cfelse>
-    <cfset dsn = "abod" />
-    <cfset suffix = "" />
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource configured in Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 
 <cfparam name="pwrong" default="" />

--- a/include/Application.cfc
+++ b/include/Application.cfc
@@ -1,20 +1,9 @@
 <cfcomponent extends="/app/Application">
   <cffunction name="onRequestStart" returntype="void" output="false">
         <cfscript>
-            // Get the first part of the server name (subdomain)
-            host = ListFirst(cgi.server_name, ".");
-
-            // Determine the datasource based on the host
-            if (host == "app" || host == "uat") {
-                datasourceName = "abo";
-                dsn = "abo";
-            } else {
-                datasourceName = "abod";
-                dsn = "abod";
-            }
-
-            application.datasourceName = datasourceName;
-            application.dsn = dsn;
+            // Use datasource from parent Application.cfc
+            application.datasourceName = application.dsn;
+            application.dsn = application.dsn;
         </cfscript>
     </cffunction>
 

--- a/include/core_nomenu.cfm
+++ b/include/core_nomenu.cfm
@@ -7,18 +7,10 @@
     
     <!--- Set current URL and host based on server name --->
     <cfset currentURL = cgi.server_name />
-    <cfset host = ListFirst(currentURL, ".") />
-    
-    <!--- Determine the data source name and version based on the host --->
-    <cfif #host# is "app">
-        <cfset dsn = "abo" />
-        <cfset rev = "1.4" />
-        <cfset suffix = "_1.4" />
-    <cfelse>
-        <cfset dsn = "abod" />
-        <cfset rev = rand() />
-        <cfset suffix = "" />
-    </cfif>
+    <!--- Use datasource configured in Application.cfc --->
+    <cfset dsn = application.dsn />
+    <cfset rev = application.rev />
+    <cfset suffix = application.suffix />
     
     <cfoutput>
         <!--- Set path and page variables --->

--- a/include/findname.cfm
+++ b/include/findname.cfm
@@ -1,5 +1,5 @@
     
-<cfquery result="result" name="getFiles" datasource="abod">
+<cfquery result="result" name="getFiles" datasource="#application.dsn#">
     SELECT `id`, `path`, `filename`
     FROM `tao_files`
     WHERE `function_id` IS NOT NULL
@@ -34,7 +34,7 @@
     <br/>
     </cfoutput>
 
-<cfquery result="result" datasource="abod">
+<cfquery result="result" datasource="#application.dsn#">
                 UPDATE tao_files
                 SET qry_name = <cfqueryparam value="#extractedQueryName#" cfsqltype="cf_sql_varchar" maxlength="255">
                 WHERE id = <cfqueryparam value="#getFiles.id#" cfsqltype="cf_sql_integer">

--- a/include/qry/admin-support.cfm
+++ b/include/qry/admin-support.cfm
@@ -5,7 +5,8 @@
    <cfparam name="select_ticketpriority" default="%" />     
        <cfparam name="select_pgid" default="%" />     
      <cfparam name="select_verid" default="%" />  
-     <cfset dsn="abo"> 
+     <!-- Use datasource from Application.cfc -->
+     <cfset dsn=application.dsn>
 <cfquery name="results"     >
     
     SELECT

--- a/include/remote_load.cfm
+++ b/include/remote_load.cfm
@@ -4,23 +4,8 @@
 
 <cfset current_ver = int(findit.verid) />
 
-<!--- Check the host environment to determine database settings --->
-<cfif host eq "app" or host eq "uat">
-    
-    <cfset dsn = "abo" />
-    <cfset rev = current_ver />
-<cfif host eq "app">
-  <cfset application.suffix = "_1.5" />
-<cfelse>
-  <cfset application.suffix = "" />
-</cfif>
-    <cfset information_schema = "actorsbusinessoffice" />
-    
-<cfelse>
-    
-    <cfset dsn = "abod" />
-    <cfset rev = rand() />
-    <cfset suffix = "" />
-    <cfset information_schema = "new_development" />
-    
-</cfif>
+<!--- Use datasource configured in Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = current_ver />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />

--- a/include/update_media_name.cfm
+++ b/include/update_media_name.cfm
@@ -1,20 +1,10 @@
 <cfparam name="mediaid" default="">
 <cfparam name="medianame" default="">
 
-    <!--- Set current URL and host based on server name --->
-    <cfset currentURL = cgi.server_name />
-    <cfset host = ListFirst(currentURL, ".") />
-    
-    <!--- Determine the data source name and version based on the host --->
-    <cfif #host# is "app">
-        <cfset dsn = "abo" />
-        <cfset rev = "1.4" />
-        <cfset suffix = "_1.4" />
-    <cfelse>
-        <cfset dsn = "abod" />
-        <cfset rev = rand() />
-        <cfset suffix = "" />
-    </cfif>
+    <!--- Use datasource configured in Application.cfc --->
+    <cfset dsn = application.dsn />
+    <cfset rev = application.rev />
+    <cfset suffix = application.suffix />
  
 
 <cfif isNumeric(mediaid) AND len(trim(medianame)) GT 0>

--- a/ipn-handler.cfm
+++ b/ipn-handler.cfm
@@ -12,7 +12,7 @@
     </cfloop>
 
     <!--- Insert into thrivecart_tbl --->
-    <cfquery datasource="abo">
+    <cfquery datasource="#application.dsn#">
         INSERT INTO thrivecart_tbl (
             CustomerFirst,
             CustomerLast,

--- a/login/login2.cfm
+++ b/login/login2.cfm
@@ -1,14 +1,9 @@
 
 
 <cfscript>
-    host = ListFirst(cgi.server_name, ".");
-    if (host == "app" || host == "uat") {
-        datasourceName = "abo";
-        dsn = "abo";
-    } else {
-        datasourceName = "abod";
-        dsn = "abod";
-    }
+    // Use datasource configured by Application.cfc
+    dsn = application.dsn;
+    datasourceName = application.dsn;
 </cfscript>
 
  

--- a/loginform.cfm
+++ b/loginform.cfm
@@ -1,18 +1,9 @@
 <cfapplication name="TAO" sessionmanagement="true">
 
-<cfset currentURL = cgi.server_name />
-<cfset host = ListFirst(currentURL, ".") />
-
-<!--- Determine the datasource and schema based on the host --->
-<cfif host is "app">
-    <cfset dsn = "abo" />
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-<cfelse>
-    <cfset dsn = "abod" />
-    <cfset suffix = "" />
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource configured in Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfif structKeyExists(cookie, "userid")>
     <cfset structDelete(cookie, "userid")>

--- a/recover/Application.cfm
+++ b/recover/Application.cfm
@@ -1,13 +1,5 @@
 <cfscript>
-    // Get the first part of the server name (subdomain)
-    host = ListFirst(cgi.server_name, ".");
-
-    // Determine the datasource based on the host
-    if (host == "app" || host == "uat") {
-        datasourceName = "abo";
-        dsn = "abo";
-    } else {
-        datasourceName = "abod";
-        dsn = "abod";
-    }
+    // Use datasource configured in parent Application.cfc
+    datasourceName = application.dsn;
+    dsn = application.dsn;
 </cfscript>

--- a/recover/index.cfm
+++ b/recover/index.cfm
@@ -2,7 +2,7 @@
 <cfparam name="p" default="" />
  
 
-<cfquery result="result" name="findit" datasource="abo">
+<cfquery result="result" name="findit" datasource="#application.dsn#">
         SELECT verid 
         FROM taoversions  
         ORDER BY isactive DESC, verid DESC 
@@ -11,23 +11,8 @@
 
 <cfset current_ver = findit.verid />
 
-<cfset host = ListFirst(cgi.server_name, ".") />
-
-<cfif host eq "app" or host eq "uat">
-        <cfset application.dsn = "abo" />
-        <cfset application.information_schema = "actorsbusinessoffice" />
-        <cfif host eq "app">
-  <cfset application.suffix = "_1.5" />
-<cfelse>
-  <cfset application.suffix = "" />
-</cfif>
-        <cfset application.rev = current_ver />
-    <cfelse>
-        <cfset application.dsn = "abod" />
-        <cfset application.information_schema = "new_development" />
-        <cfset application.suffix = "" />
-        <cfset application.rev = 1 />
-    </cfif>
+<!--- Use datasource configured in Application.cfc --->
+<cfset dsn = application.dsn />
 
 <cfif #isdefined('recoverid')# >
 <cfoutput>Select * from taousers where userid = #recoverid#</cfoutput>

--- a/recover/setup2.cfm
+++ b/recover/setup2.cfm
@@ -1,23 +1,12 @@
 <Cfparam name="pass1" default="" />
 
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    
-    <cfset dsn = "abo" />
-    
-    <cfelse>
-  
-        <cfset dsn = "abod" />
-
-</cfif>
+<!--- Use datasource configured in Application.cfc --->
+<cfset dsn = application.dsn />
     
     
 <cfset new_passwordSalt=hash(generateSecretKey("AES"),"SHA-512") />
 
-        <cfquery name="update" datasource="abo"    >
+        <cfquery name="update" datasource="#application.dsn#"    >
     UPDATE taousers
     set passwordHash = <cfqueryparam cfsqltype="char" value="#hash(pass1 & new_passwordSalt,'SHA-512')#" />
             ,recover = ''

--- a/sched/Application.cfc
+++ b/sched/Application.cfc
@@ -1,6 +1,6 @@
 <cfcomponent output="false">
 
-  <cfquery result="result" name="findit" datasource="abo">
+  <cfquery result="result" name="findit" datasource="#application.dsn#">
     SELECT verid
     FROM taoversions
     ORDER BY isactive DESC, verid DESC
@@ -9,22 +9,12 @@
 
   <cfset current_ver=findit.verid/>
 
-  <cfset host=ListFirst(cgi.server_name, ".")/>
-
   <Cfset application.dbug = "Y" />
-  
 
-    <cfif #host# is "app">
-        <cfset application.dsn="abo"/>
-    <cfset application.information_schema="actorsbusinessoffice"/>
-    <cfset application.suffix="_1.5"/>
-        <cfelse>
-            
-          <cfset application.dsn="abo"/>
-    <cfset application.information_schema="actorsbusinessoffice"/>
-    <cfset application.suffix="_1.5"/>
-                
-    </cfif>
+    <!--- Use datasource from parent Application.cfc --->
+    <cfset application.dsn = application.dsn />
+    <cfset application.information_schema = application.information_schema />
+    <cfset application.suffix = application.suffix />
     
 
     <cfset application.rev=current_ver />

--- a/sched/auddialects_fix.cfm
+++ b/sched/auddialects_fix.cfm
@@ -1,21 +1,10 @@
   <h3>Auddialects</h3>
     
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/audgenres_fix.cfm
+++ b/sched/audgenres_fix.cfm
@@ -1,21 +1,10 @@
   <h3>audgenres</h3>
     
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/audnetworks_fix.cfm
+++ b/sched/audnetworks_fix.cfm
@@ -1,21 +1,10 @@
   <h3>Audnetworks</h3>
     
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/audplatforms_fix.cfm
+++ b/sched/audplatforms_fix.cfm
@@ -1,21 +1,10 @@
   <h3>Audaudplatforms</h3>
     
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/audtones_fix.cfm
+++ b/sched/audtones_fix.cfm
@@ -1,21 +1,10 @@
   <h3>Style / Format</h3>
     
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/extracts_for_multiple.cfm
+++ b/sched/extracts_for_multiple.cfm
@@ -1,6 +1,6 @@
 <cfparam name="mr" default="3" />
 
-<cfquery result="result" name="getFiles" datasource="abod" maxrows="#mr#">
+<cfquery result="result" name="getFiles" datasource="#application.dsn#" maxrows="#mr#">
     SELECT id, `path`, `filename`
     FROM tao_files
     WHERE filename = 'account_info.cfm'
@@ -52,7 +52,7 @@
                     <cfset qryNameSanitized = REReplace(qryName, "[^a-zA-Z0-9_]", "", "ALL")>
 
                     <!--- Generate new query filename --->
-                    <cfquery result="result" name="getNextId" datasource="abod">
+                    <cfquery result="result" name="getNextId" datasource="#application.dsn#">
                         SELECT IFNULL(MAX(id), 0) + 1 AS nextId FROM tao_files
                     </cfquery>
 
@@ -155,7 +155,7 @@
                     <cfset qryDetails = REReplace(qryDetails, "[\s]+", " ", "ALL")>
 
                     <!--- Insert into database --->
-                    <cfquery result="result" datasource="abod">
+                    <cfquery result="result" datasource="#application.dsn#">
                         INSERT INTO tao_files (
                             filename,
                             status,
@@ -192,7 +192,7 @@
         <cffile action="write" file="#newMainFilePath#" output="#fileContent#">
 
         <!--- Mark file as processed --->
-        <cfquery result="result" datasource="abod">
+        <cfquery result="result" datasource="#application.dsn#">
             UPDATE tao_files
             SET qry_extract_yn = 1
             WHERE id = <cfqueryparam value="#getFiles.id#" cfsqltype="cf_sql_integer">

--- a/sched/hash_loop.cfm
+++ b/sched/hash_loop.cfm
@@ -1,13 +1,13 @@
  
 
-<cfquery result="result" name="getUsers" datasource="abo" >
+<cfquery result="result" name="getUsers" datasource="#application.dsn#" >
   SELECT * FROM taousers_tbl
 </cfquery>
 
 <cfloop query="getUsers">
   <cfset new_passwordSalt = hash(generateSecretKey("AES"),"SHA-512")>
 
-<cfquery result="result" name="setHashedPassword" datasource="abo" >
+<cfquery result="result" name="setHashedPassword" datasource="#application.dsn#" >
     UPDATE taousers_tbl
     SET
       passwordHash = <cfqueryparam cfsqltype="char" value="#hash(userPassword & new_passwordSalt,'SHA-512')#">,

--- a/sched/remote_load.cfm
+++ b/sched/remote_load.cfm
@@ -1,14 +1,5 @@
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-    <cfset rev = "1.4" />
-    <cfset suffix = "_1.5" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
 

--- a/sched/setup_loop.cfm
+++ b/sched/setup_loop.cfm
@@ -1,19 +1,8 @@
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abod" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <cfset rev = rand() />
 

--- a/sched/sitelinksfix.cfm
+++ b/sched/sitelinksfix.cfm
@@ -2,7 +2,7 @@
 <cfparam name="select_userid" default="793" />
 
 <cfset n=0 />
-<cfset dsn = "abo" />
+<cfset dsn = application.dsn />
 <cfset dbug = "Y"  />
 
 <cfquery result="result" datasource="#dsn#" name="z" maxrows="5">

--- a/sched/thrivecart_process.cfm
+++ b/sched/thrivecart_process.cfm
@@ -1,21 +1,10 @@
 <cfset dbug="N" />
 
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-  <cfoutput>  <cfset rev = "#rand()#" /> </cfoutput>
-    <cfset suffix = "_1.5" />
-    <cfset information_schema = "actorsbusinessoffice" />
-    <cfelse>
-  <cfset dsn = "abo" />
-<cfset rev = rand() />
-        <cfset suffix = "" />
-        
-    <cfset information_schema = "new_development" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
+<cfset rev = application.rev />
+<cfset suffix = application.suffix />
+<cfset information_schema = application.information_schema />
 
 <Cfset to_email="kevinking7135@gmail.com" />
 

--- a/sched/ticketfix.cfm
+++ b/sched/ticketfix.cfm
@@ -1,13 +1,13 @@
 
 
-<cfquery result="result" datasource="abod" name="x">
+<cfquery result="result" datasource="#application.dsn#" name="x">
 SELECT * FROM tickets WHERE verid = 7 AND ticketstatus = 'Implemented'
  
 </cfquery>
 
 <cfloop query="x">
     
-    <cfquery result="result" name="add" datasource="abo">
+    <cfquery result="result" name="add" datasource="#application.dsn#">
         INSERT INTO tickets (pgid,ticketName,ticketdetails,tickettype,userid,ticketactive,ticketstring,verid,ticketresponse,ticketcreateddate,ticketstatus,tickettype,environ,ticketpriority,esthours)
         Values (
         <cfqueryparam value="#x.pgid#" cfsqltype="cf_sql_integer" />

--- a/sched/tickets_loop.cfm
+++ b/sched/tickets_loop.cfm
@@ -1,9 +1,9 @@
-<cfquery result="result" datasource="abod" name="z"  >
+<cfquery result="result" datasource="#application.dsn#" name="z"  >
 Select * from tickets
 </cfquery>  
 <cfloop query="z">
 
-<cfquery result="result" datasource="abo" name="update"  >   
+<cfquery result="result" datasource="#application.dsn#" name="update"  >
         update tickets
         set ticketname  = <cfqueryparam cfsqltype="cf_sql_varchar" value="#z.ticketname#" />
     ,ticketstatus  = <cfqueryparam cfsqltype="cf_sql_varchar" value="#z.ticketstatus#" />

--- a/sched/user_setup_core.cfm
+++ b/sched/user_setup_core.cfm
@@ -1,10 +1,5 @@
-<cfset host = ListFirst(cgi.server_name, ".") />
-
-<cfif host eq "app" or host eq "uat">
-    <cfset dsn = "abo" />
-<cfelse>
-    <cfset dsn = "abod" />
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />
 
 <cfparam name="dbugz" default="N" />
 

--- a/sched/usercontact.cfm
+++ b/sched/usercontact.cfm
@@ -1,14 +1,5 @@
-    <cfset currentURL=cgi.server_name />
-    <cfset host=ListFirst(currentURL, "." ) />
-
-    <cfif #host# is "app">
-        <cfset dsn="ABO">
-       
-            
-        <cfelse>
-    <cfset dsn = "abod" >
-                
-    </cfif>
+    <!--- Use datasource from Application.cfc --->
+    <cfset dsn = application.dsn>
 
 <cfquery result="result" name="loginQuery" datasource="#dsn#" >
   SELECT * FROM taousers where contactid is null

--- a/sched/usersprod_loop.cfm
+++ b/sched/usersprod_loop.cfm
@@ -1,12 +1,12 @@
  
 
-<cfquery result="result" name="x" datasource="abo" >
+<cfquery result="result" name="x" datasource="#application.dsn#" >
   SELECT * FROM taousers_tbl
 </cfquery>
 
 <cfloop query="x">
 
-<cfquery result="result" name="setHashedPassword" datasource="abod" >
+<cfquery result="result" name="setHashedPassword" datasource="#application.dsn#" >
     UPDATE taousers_tbl
     SET
       useremail  = <cfqueryparam cfsqltype="varchar" value="#x.useremail#">

--- a/services/Application.cfm
+++ b/services/Application.cfm
@@ -1,14 +1,7 @@
- <cfscript>
- 
-    host = ListFirst(cgi.server_name, ".");
-
-if (host == "app" || host == "uat") {
-        datasourceName = "abo";
-        dsn = "abo";
-    } else {
-        datasourceName = "abod";
-        dsn = "abod";
-    }
+<cfscript>
+    // Use datasource from parent Application.cfc
+    datasourceName = application.dsn;
+    dsn = application.dsn;
 </cfscript>
 
 <cfapplication 

--- a/setup/Application.cfc
+++ b/setup/Application.cfc
@@ -1,20 +1,9 @@
 <cfcomponent extends="/app/Application">
   <cffunction name="onRequestStart" returntype="void" output="false">
         <cfscript>
-            // Get the first part of the server name (subdomain)
-            host = ListFirst(cgi.server_name, ".");
-
-            // Determine the datasource based on the host
-            if (host == "app" || host == "uat") {
-                datasourceName = "abo";
-                dsn = "abo";
-            } else {
-                datasourceName = "abod";
-                dsn = "abod";
-            }
-
-            application.datasourceName = datasourceName;
-            application.dsn = dsn;
+            // Use datasource set by parent Application.cfc
+            application.datasourceName = application.dsn;
+            application.dsn = application.dsn;
         </cfscript>
     </cffunction>
 

--- a/setup/Filecheck.cfm
+++ b/setup/Filecheck.cfm
@@ -1,6 +1,8 @@
 <cfset z = 0>
      <cfset currentURL = cgi.server_name />
     <cfset host = ListFirst(currentURL, ".") />
+    <!--- Use datasource from Application.cfc --->
+    <cfset dsn = application.dsn />
 <cfoutput>
 <cfdirectory action="list" directory="D:\home\theactorsoffice.com\wwwroot\#host#-subdomain\include\" name="listRoot">
 </cfoutput>
@@ -11,7 +13,7 @@
 
 <cfif #fileext# is "cfm">
 
-<CFQUERY RESULT="RESULT" name="bro_add" datasource="abo" >
+<CFQUERY RESULT="RESULT" name="bro_add" datasource="#application.dsn#" >
 		select * from bigbrother where script_name = '/include/#name#'
           </CFQUERY>
           

--- a/share/Applicationx.cfc
+++ b/share/Applicationx.cfc
@@ -3,24 +3,12 @@
 
   <cffunction name="onRequestStart" returntype="void" output="false">
         <cfscript>
-            // Get the first part of the server name (subdomain)
-            host = ListFirst(cgi.server_name, ".");
-
-            // Determine the datasource based on the host
-            if (host == "app" || host == "uat") {
-                datasourceName = "abo";
-                dsn = "abo";
-            } else {
-                datasourceName = "abod";
-                dsn = "abod";
-            }
-
-            // Optionally store the datasource in application or request scope
+            // Use datasource configured in Application.cfc
             this.datasource = application.dsn;
-            application.datasourceName = datasourceName;
-            application.dsn = dsn;
-               application.baseMediaPath = "C:\home\theactorsoffice.com\media-" & this.datasource;
-    application.baseMediaUrl = "/media-" & this.datasource;
+            application.datasourceName = application.dsn;
+            application.dsn = application.dsn;
+            application.baseMediaPath = "C:\home\theactorsoffice.com\media-" & this.datasource;
+            application.baseMediaUrl = "/media-" & this.datasource;
         </cfscript>
     </cffunction>
 

--- a/share/remote_load.cfm
+++ b/share/remote_load.cfm
@@ -1,10 +1,2 @@
-<cfset currentURL = cgi.server_name />
-
-<cfset host = ListFirst(currentURL, ".") />
-
-<cfif #host# is "app">
-    <cfset dsn = "abo" />
-    <cfelse>
-  <cfset dsn = "abod" />
-
-</cfif>
+<!--- Use datasource from Application.cfc --->
+<cfset dsn = application.dsn />


### PR DESCRIPTION
## Summary
- set `dsn`, `suffix`, etc. from `application` scope
- remove host-based datasource logic in many pages
- use `application.dsn` for all queries

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686897e012088322be6bfea6bb8c09f0