### PR TITLE
Fix loginform.cfm application variables

### DIFF
--- a/loginform.cfm
+++ b/loginform.cfm
@@ -1,5 +1,23 @@
 <cfapplication name="TAO" sessionmanagement="true">
 
+<!--- Ensure required application variables exist --->
+<cfif NOT structKeyExists(application, "dsn")>
+    <cfset host = ListFirst(cgi.server_name, ".") />
+    <cfif host EQ "app">
+        <cfset application.dsn = "abo" />
+    <cfelse>
+        <cfset application.dsn = "abod" />
+    </cfif>
+</cfif>
+
+<cfif NOT structKeyExists(application, "information_schema")>
+    <cfset application.information_schema = "actorsbusinessoffice" />
+</cfif>
+
+<cfif NOT structKeyExists(application, "suffix")>
+    <cfset application.suffix = "_1.5" />
+</cfif>
+
 <!--- Use datasource configured in Application.cfc --->
 <cfset dsn = application.dsn />
 <cfset suffix = application.suffix />


### PR DESCRIPTION
## Summary
- guard against missing application variables when rendering `loginform.cfm`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868a18875e4832290fefa68c09a7892