### PR TITLE
Fix missing DSN in login2

### DIFF
--- a/login/login2.cfm
+++ b/login/login2.cfm
@@ -1,5 +1,25 @@
 
 
+<cfapplication name="TAO" sessionmanagement="true">
+
+<!--- Ensure required application variables exist --->
+<cfif NOT structKeyExists(application, "dsn")>
+    <cfset host = ListFirst(cgi.server_name, ".") />
+    <cfif host EQ "app">
+        <cfset application.dsn = "abo" />
+    <cfelse>
+        <cfset application.dsn = "abod" />
+    </cfif>
+</cfif>
+
+<cfif NOT structKeyExists(application, "information_schema")>
+    <cfset application.information_schema = "actorsbusinessoffice" />
+</cfif>
+
+<cfif NOT structKeyExists(application, "suffix")>
+    <cfset application.suffix = "_1.5" />
+</cfif>
+
 <cfscript>
     // Use datasource configured by Application.cfc
     dsn = application.dsn;


### PR DESCRIPTION
## Summary
- ensure application variables exist in `login/login2.cfm`
- use same DSN logic as loginform so login processing works outside the `/app` folder

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6868b16efe6083228acda3d4aad0d083