### PR TITLE
Add AJAX reminders pane

### DIFF
--- a/app/ajax/get_reminders.cfm
+++ b/app/ajax/get_reminders.cfm
@@ -1,0 +1,25 @@
+<cfcontent type="application/json; charset=utf-8">
+<cfset dsn = application.dsn>
+<cfparam name="url.showInactive" default="0">
+
+<cfquery name="qRem" datasource="#dsn#">
+  SELECT id, reminder_text, status, due_date, last_updated
+  FROM reminders
+  <cfif NOT val(url.showInactive)>
+    WHERE status = 'Pending'
+  </cfif>
+  ORDER BY due_date
+</cfquery>
+
+<cfset data = []>
+<cfloop query="qRem">
+  <cfset arrayAppend(data, {
+    id: qRem.id,
+    reminder_text: qRem.reminder_text,
+    due_date: dateFormat(qRem.due_date, "mm/dd/yyyy"),
+    status: qRem.status,
+    last_updated: dateFormat(qRem.last_updated, "mm/dd/yyyy")
+  })>
+</cfloop>
+
+<cfoutput>#serializeJSON({data:data})#</cfoutput>

--- a/app/ajax/update_reminder_status.cfm
+++ b/app/ajax/update_reminder_status.cfm
@@ -1,0 +1,16 @@
+<cfcontent type="application/json; charset=utf-8">
+<cfset dsn = application.dsn>
+<cfparam name="form.reminder_id" default="">
+<cfparam name="form.new_status" default="">
+
+<cfif isNumeric(form.reminder_id) AND listFind('Pending,Completed,Skipped', form.new_status)>
+  <cfquery datasource="#dsn#">
+    UPDATE reminders
+    SET status = <cfqueryparam value="#form.new_status#" cfsqltype="cf_sql_varchar">,
+        last_updated = <cfqueryparam value="#now()#" cfsqltype="cf_sql_timestamp">
+    WHERE id = <cfqueryparam value="#form.reminder_id#" cfsqltype="cf_sql_integer">
+  </cfquery>
+  <cfoutput>#serializeJSON({"success": true})#</cfoutput>
+<cfelse>
+  <cfoutput>#serializeJSON({"success": false, "error": "Invalid input"})#</cfoutput>
+</cfif>

--- a/include/reminder_pane.cfm
+++ b/include/reminder_pane.cfm
@@ -1,128 +1,83 @@
-<cfset dbug="N" />
-<cfparam name="form.filter_completed" default="0">
-<cfparam name="form.filter_skipped" default="0">
-<cfparam name="form.filter_upcoming" default="1">
-<cfparam name="form.filter_pending" default="1">
-<!--- Set default parameters --->
-<cfparam name="zquery" default="">
-<cfset unchecked_style="mdi mdi-checkbox-blank-outline font-24 mr-1">
-<cfset checked_style="mdi mdi-checkbox-marked-outline font-24 mr-1">
-<cfparam name="hide_completed_check" default="">
-<cfparam name="hide_completed" default="N">
-
-<!--- Check if completed items should be hidden --->
-<cfif #hide_completed# EQ "Y">
-  <cfset hide_completed_check = "checked">
-</cfif>
-
+<cfcontent type="text/html; charset=utf-8">
 <cfoutput>
-  <div class="d-flex justify-content-between">
-    <div class="float-left">
-      <!--- Filter checkboxes --->
-      <label><input type="checkbox" class="status-filter" value="completed" checked> Completed</label>
-      <label><input type="checkbox" class="status-filter" value="skipped" checked> Skipped</label>
-      <label><input type="checkbox" class="status-filter" value="upcoming" checked> Upcoming</label>
-      <label><input type="checkbox" class="status-filter" value="pending" checked> Pending</label>
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h4 class="mb-0">Reminders</h4>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="showInactive">
+      <label class="form-check-label" for="showInactive">Show inactive records</label>
     </div>
   </div>
+  <div class="card-body">
+    <div id="reminderMsg" class="alert d-none" role="alert"></div>
+    <table id="remindersTable" class="table table-striped table-bordered" style="width:100%">
+      <thead>
+        <tr>
+          <th>Action</th>
+          <th>Reminder Text</th>
+          <th>Due Date</th>
+          <th>Status</th>
+          <th>Last Updated</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
 </cfoutput>
 
-<div id="tab-relationship-view" style="flex: 1 1 auto;">
-  <!--- Loop through active systems --->
-  <cfloop query="sysActive">
-
-    <cfif #LCase(sysActive.sustatus)# EQ "active">
-      <cfset showstatus = "pending">
-    <cfelse>
-      <cfset showstatus = "#LCase(sysActive.sustatus)#">
-    </cfif>
-
-    <cfinclude template="/include/qry/notsactive_510_1.cfm">
-
-    <cfoutput>
-      <div class="row">
-        <div class="col-md-12">
-          <h4>
-            #sysActive.systemName#
-            <a href="" title="click for details" data-bs-toggle="modal" data-bs-target="##action#sysActive.suid#-modal">
-              <i class="fe-info font-14 mr-1"></i>
-            </a>
-            <cfif #sysActive.sustatus# EQ "Completed">
-              <span class="badge bg-warning rounded-pill">Completed</span>
-            </cfif>
-            <a title="Delete System" href="DeleteModal.cfm?rpgid=40&recid=#sysActive.suid#&t4=1" data-bs-toggle="modal" data-bs-target="##remoteDeleteForm#sysActive.suid#">
-              <i class="fe-trash-2"></i>
-            </a>
-          </h4>
-        </div>
-      </div>
-    </cfoutput>
-
-    <!--- No active items --->
-    <cfif #notsActive.recordcount# EQ 0>
-      <p>No action items to show!</p>
-    </cfif>
-
-    <!--- Loop through active notifications --->
-    <cfif #notsActive.recordcount# NEQ 0>
-      <div class="row">
-        <cfloop query="notsActive">
-          <cfoutput>
-            <div class="col-md-12 reminder #LCase(notsActive.notstatus)#" style="padding-bottom:10px; margin-left:30px;">
-              <cfif notsActive.notstatus EQ "Pending" OR notsActive.notstatus EQ "Upcoming">
-                <a href="/include/complete_not.cfm?notid=#notsActive.notid#&notstatus=Completed&hide_completed=#hide_completed#">
-              </cfif>
-
-              <i class="mdi mdi-checkbox-#notsActive.checktype#-outline font-24 mr-1" style="vertical-align: middle; color:###notsActive.status_color#"></i>
-
-              <cfif notsActive.notstatus EQ "Pending" OR notsActive.notstatus EQ "Upcoming">
-                </a>
-              </cfif>
-
-              #notsActive.delstart# #notsActive.actiondetails# #notsActive.delend#
-
-              <cfif len(notsActive.notEndDate)>
-                (#notsActive.notstatus# #this.formatDate(notsActive.notEndDate)#)
-              <cfelse>
-                (Due Date #this.formatDate(notsActive.notstartdate)#)
-              </cfif>
-
-              <cfif notsActive.ispastdue EQ 1>
-                <span class="badge badge-soft-danger">Past Due</span>
-              </cfif>
-
-              <a href="" title="Click for details" data-bs-toggle="modal" data-bs-target="##action#notsActive.actionid#-modal">
-                <i class="fe-info font-14 mr-1"></i>
-              </a>
-
-              <cfif notsActive.notstatus EQ "Pending" OR notsActive.notstatus EQ "Upcoming">
-                <a href="/include/complete_not.cfm?notid=#notsActive.notid#&notstatus=Skipped&hide_completed=#hide_completed#" title="Skip reminder">
-                  <span class="badge badge-blue" style="margin-left:10px">x Skip</span>
-                </a>
-              </cfif>
-            </div>
-          </cfoutput>
-        </cfloop>
-      </div>
-    </cfif>
-  </cfloop>
-</div>
+<!-- DataTables & Dependencies -->
+<link rel="stylesheet" href="/app/assets/css/datatables.min.css">
+<script src="/app/assets/js/jquery-3.6.0.min.js"></script>
+<script src="/app/assets/js/datatables.min.js"></script>
 
 <script>
-document.addEventListener("DOMContentLoaded", function () {
-  document.querySelectorAll(".status-filter").forEach(cb => {
-    cb.addEventListener("change", filterReminders);
+$(document).ready(function(){
+  var table = $('#remindersTable').DataTable({
+    ajax: {
+      url: '/app/ajax/get_reminders.cfm',
+      dataSrc: 'data',
+      data: function(d){
+        d.showInactive = $('#showInactive').prop('checked') ? 1 : 0;
+      }
+    },
+    columns: [
+      { data: null, orderable:false, render: function(data){
+          return '<button class="btn btn-sm btn-success complete" data-id="'+data.id+'">Complete</button>'+
+                 ' <button class="btn btn-sm btn-warning skip" data-id="'+data.id+'">Skip</button>';
+        }
+      },
+      { data: 'reminder_text' },
+      { data: 'due_date' },
+      { data: 'status' },
+      { data: 'last_updated' }
+    ],
+    order: [[2,'asc']]
   });
-  filterReminders();
+
+  $('#showInactive').on('change', function(){
+    table.ajax.reload();
+  });
+
+  $('#remindersTable').on('click', '.complete', function(){
+    updateStatus($(this).data('id'), 'Completed');
+  });
+
+  $('#remindersTable').on('click', '.skip', function(){
+    updateStatus($(this).data('id'), 'Skipped');
+  });
+
+  function updateStatus(id, status){
+    $.post('/app/ajax/update_reminder_status.cfm', {reminder_id:id, new_status:status}, function(resp){
+      if(resp.success){
+        $('#reminderMsg').removeClass('d-none alert-danger').addClass('alert-success').text('Status updated');
+        table.ajax.reload(null,false);
+      }else{
+        $('#reminderMsg').removeClass('d-none alert-success').addClass('alert-danger').text(resp.error || 'Error updating');
+      }
+    }, 'json').fail(function(){
+      $('#reminderMsg').removeClass('d-none alert-success').addClass('alert-danger').text('Error updating');
+    });
+  }
 });
-
-function filterReminders() {
-  const activeStatuses = Array.from(document.querySelectorAll(".status-filter:checked")).map(cb => cb.value);
-  document.querySelectorAll(".reminder").forEach(reminder => {
-    const classes = reminder.className.split(" ");
-    reminder.style.display = classes.some(c => activeStatuses.includes(c)) ? '' : 'none';
-  });
-}
 </script>
-
-<cfset script_name_include="/include/#ListLast(GetCurrentTemplatePath(), " \ ")#">


### PR DESCRIPTION
## Summary
- rewrite reminder_pane.cfm using Bootstrap and DataTables
- add get_reminders.cfm endpoint returning JSON
- add update_reminder_status.cfm for AJAX updates

## Testing
- `npx --yes stylelint "**/*.css"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686eb551a6fc8322a259a75f35a9cbb5