### PR TITLE
TAO-WIZARD-FIX-01 D4 follow-up: remove non-working step 7 Edit buttons

### DIFF
--- a/app/assets/js/setup-wizard.js
+++ b/app/assets/js/setup-wizard.js
@@ -287,17 +287,6 @@
         loadStep(prevStep(step));
     });
 
-    // Complete-step (step 7) summary "Edit" links jump back to the relevant
-    // wizard step. They previously pointed at /app/* routes, which the
-    // Setup-status guard in Application.cfc redirects back to the wizard
-    // (apparent no-op page reload). Delegated from $content because the step
-    // markup is injected after load. Items with no step render no Edit link.
-    $content.on('click', '.summary-edit', function(e) {
-        e.preventDefault();
-        var s = parseInt($(this).attr('data-edit-step'), 10);
-        if (s) { loadStep(s); }
-    });
-
     // Skip
     $btnSkip.on('click', function() {
         if (saving) return;

--- a/app/setup-wizard/steps/step7.cfm
+++ b/app/setup-wizard/steps/step7.cfm
@@ -67,7 +67,6 @@
                 #encodeForHTML(qProfile.userFirstName)# #encodeForHTML(qProfile.userLastName)#<br>
                 <small class="text-muted">#encodeForHTML(qProfile.tzname)# &middot; #encodeForHTML(qProfile.dateformat)#</small>
             </div>
-            <a href="##" class="summary-edit" data-edit-step="1">Edit</a>
         </div>
     </div>
 
@@ -83,7 +82,6 @@
                     None added yet
                 </cfif>
             </div>
-            <a href="##" class="summary-edit" data-edit-step="2">Edit</a>
         </div>
     </div>
 
@@ -99,7 +97,6 @@
                     None added yet
                 </cfif>
             </div>
-            <a href="##" class="summary-edit" data-edit-step="3">Edit</a>
         </div>
     </div>
 
@@ -117,9 +114,6 @@
                     Skipped
                 </cfif>
             </div>
-<cfif val(qProfile.isAuditionModule)>
-            <a href="##" class="summary-edit" data-edit-step="4">Edit</a>
-            </cfif>
         </div>
     </div>
 
@@ -135,7 +129,6 @@
                     None set up yet
                 </cfif>
             </div>
-            <a href="##" class="summary-edit" data-edit-step="5">Edit</a>
         </div>
     </div>
 
@@ -151,7 +144,6 @@
                     None added yet
                 </cfif>
             </div>
-            <a href="##" class="summary-edit" data-edit-step="6">Edit</a>
         </div>
     </div>
 


### PR DESCRIPTION
The summary-step Edit links (added to jump back to a wizard step) did not work in testing. Per request, remove them entirely: drop the six .summary-edit anchors from step7.cfm and the now-dead delegated click handler from setup-wizard.js. The .summary-edit CSS rule is left in place (harmless, unused).