### PR TITLE
fix(v2.1.1): resolve verid 46 tickets 1636 and 2161

### DIFF
--- a/ajax/import-auditions/parse.cfm
+++ b/ajax/import-auditions/parse.cfm
@@ -307,8 +307,11 @@
             <cfset addDebug("Data rows parsed: " & arrayLen(variables.dataRows))>
 
         <cfelseif variables.job.file_type eq "xls" or variables.job.file_type eq "xlsx">
-            <!--- Parse Excel using cfspreadsheet --->
-            <cfspreadsheet action="read" src="#variables.filePath#" query="spreadsheetData" headerrow="1">
+            <!--- Parse Excel using cfspreadsheet. excludeHeaderRow keeps the header
+                  out of the data rows so XLSX behaves like the CSV branch above,
+                  which explicitly starts its data loop at row 2. Without it the
+                  header row is ingested as a phantom data row. --->
+            <cfspreadsheet action="read" src="#variables.filePath#" query="spreadsheetData" headerrow="1" excludeHeaderRow="true">
 
             <!--- Get headers from column names --->
             <cfset variables.rawHeaders = listToArray(variables.spreadsheetData.columnList)>

--- a/docs/plans/v2.1.1_verid46_test_plan.md
+++ b/docs/plans/v2.1.1_verid46_test_plan.md
@@ -1,0 +1,100 @@
+# v2.1.1 (verid 46) — Test Plan for Shipped Fixes
+
+Covers the 3 code changes currently in the working tree. Run on **dev** first; then re-verify on prod after deploy.
+
+Changed files:
+- `include/formatPhoneNumber.cfm` (ticket 1636)
+- `ajax/import-auditions/parse.cfm` (ticket 2161, bug #1 candidate)
+- `services/AuditionImportService.cfc` (ticket 2161, bug #3 residual)
+
+---
+
+## 1. Phone formatting — `include/formatPhoneNumber.cfm` (1636)
+
+**What changed:** Removed the trailing overwrite that reset `formatPhoneNumber`/`anchorPhoneNumber` to the raw digit string, discarding all formatting.
+
+### UI steps
+1. Open a contact with a **10-digit** US phone (e.g. `3105551234`).
+   - Contact view (`contact_view.cfm`), contact pane (`contact_pane.cfm`), and contact info (`contact_info.cfm`) should all display **`(310) 555-1234`**, not `3105551234`.
+   - The click-to-call anchor (`tel:` link) should use `310-555-1234`.
+2. Open a contact with a **non-10-digit** phone (e.g. `+44 20 7946`, `555-1234`, extension).
+   - Displays the original string unchanged; anchor uses the cleaned digits. No error, no blank.
+3. Open a contact with an **empty** phone field — renders blank, no error.
+
+### Edge cases
+- Number with formatting already in it (`(310) 555-1234` stored) — clean path strips to 10 digits, re-formats consistently.
+- Number with leading `1` (11 digits) — falls to else branch, shown as-is (documented behavior, not 10-digit path).
+
+### Pass criteria
+10-digit numbers render formatted in all 3 consumers AND the `tel:` anchor is dialable. Non-10-digit numbers are untouched. No CF error on empty/malformed input.
+
+---
+
+## 2. XLSX import header row — `ajax/import-auditions/parse.cfm` (2161 #1)
+
+**What changed:** Added `excludeHeaderRow="true"` to the `cfspreadsheet` read so the header is not ingested as a phantom data row (CSV branch already loops from row 2).
+
+### UI steps
+1. Import an **XLSX** audition file with a header row + **1 data row**.
+   - Review grid shows **exactly 1** row (previously the header could appear as a bogus row, or the single record showed "no data").
+   - The one data row maps to the correct columns; no row whose values equal the column headers.
+2. Import an XLSX with header + **N data rows** → grid shows exactly **N** rows.
+3. Import the equivalent **CSV** of the same data → row count matches the XLSX import (parity check).
+4. Import an **XLS** (old format) file → same behavior as XLSX.
+
+### Edge cases
+- XLSX with a blank first data row under the header — should still not treat the header as data.
+- XLSX where a data value coincidentally equals a header label — correct row still parsed.
+- File with header only, **0 data rows** → grid shows 0 rows, friendly empty state, no crash.
+
+### Pass criteria
+Parsed row count = actual data rows (header excluded), and XLSX count matches CSV count for identical data. No phantom header-as-data row.
+
+> Note: bug #1's original repro ("single record shows no data") still needs the reporter's failing spreadsheet to confirm this is the same defect. This test validates the header-row fix; if the reporter's file still fails, attach it and re-open.
+
+---
+
+## 3. Category resolution in edit modal — `services/AuditionImportService.cfc` (2161 #3)
+
+**What changed:** `updateRowFields` `case "category"` now resolves a typed category name to an `audsubcatid` fact (via `resolveCategoryToSubCatId`), so the review grid's required-category check clears — mirroring import-time resolution. Skips if an explicit `audsubcatid` already exists so a dropdown pick is never clobbered.
+
+### UI steps
+1. Import a file that produces a row **flagged "category required"** (missing/unresolved category).
+2. In the review grid, open the row's **edit modal** and type a **valid category name** (one that resolves, e.g. an existing category label). Save.
+   - The "category required" error should **clear** on recompute.
+   - Row status moves toward ready (assuming no other blocking problems).
+3. Verify persistence: the row now has an `audsubcatid` fact with the resolved id.
+4. **Finalize** the import → the audition record lands with the correct subcategory. No double-insert on a second finalize (idempotency).
+
+### Edge cases (must not regress)
+- **Dropdown already chose a subcategory**, then user also types a category name → the explicit `audsubcatid` is **preserved** (typed name does not overwrite it). This is the `qExplicitCat.recordCount eq 0` guard.
+- Type an **unresolvable** category name → no `audsubcatid` written; required-check still flags it (graceful, no crash — `try/catch (eCat)` swallows resolution failure).
+- Type an **empty** value → `len(normalizedVal)` guard skips resolution entirely.
+- Category name with odd casing/whitespace → resolves the same as import-time (parity with `recompute.cfm`).
+
+### SQL verification
+```sql
+-- After typing a valid category in the edit modal for a known row_id:
+SELECT field_name, normalized_value, is_valid, validation_code
+FROM import_auditions_facts
+WHERE row_id = <ROW_ID> AND field_name IN ('category','audsubcatid')
+ORDER BY field_name;
+-- Expect: an 'audsubcatid' row with a numeric normalized_value and is_valid = 1.
+
+-- Guard check: pre-set an explicit audsubcatid, then type a category name.
+-- The audsubcatid normalized_value must be UNCHANGED afterward.
+```
+
+### Pass criteria
+Typing a resolvable category clears the required error and writes a valid `audsubcatid`; an existing explicit subcategory is never overwritten; unresolvable/empty input degrades gracefully; finalize stays idempotent.
+
+---
+
+## Regression sweep (all three)
+- Full audition import happy path (CSV + XLSX): parse → review → edit a field → finalize → record created correctly.
+- Contact pages render (phone, and everything around it) with no CF errors in `contact_export_errors` / application log.
+- No new entries in the CF error log during the above.
+
+## Environments
+1. **Dev** (`abod` / `new_development`) — run everything above with test data.
+2. **Prod** (`abo` / `actorsbusinessoffice`) — after deploy, re-run sections 1–3 UI steps as smoke tests against the real verid-46 repro cases.

--- a/docs/plans/v2.1.1_verid46_ticket_plan.md
+++ b/docs/plans/v2.1.1_verid46_ticket_plan.md
@@ -1,0 +1,218 @@
+# TAO v2.1.1 (verid 46) — Non-Closed Ticket Remediation Plan
+
+**Release:** 2.1.1 beta (Patch) — `taoversions.verid = 46`, 400 budgeted hours
+**Scope:** all tickets where `ticketStatus <> 'Closed'` and `IsDeleted = 0`
+**Ticket count:** 12 (9 Pending, 2 Tested - Bug, 1 Implemented)
+**Authoring date:** 2026-07-02
+**Data source:** live read of `actorsbusinessoffice` (prod) + `new_development` (dev) plus a per-ticket parallel codebase investigation.
+
+> This document is both the plan and the working tracker. Each ticket has a **Status log** line that is updated as work proceeds. "Verify-only" tickets are already fixed in dev code and/or the DB; their remaining work is a functional retest and a production deploy confirmation, which cannot be executed from a code session with no running app.
+
+---
+
+## Ground-truth facts established up front
+
+These were confirmed against the live DB and remove a whole class of speculation:
+
+| Column | prod (`actorsbusinessoffice`) | dev (`new_development`) |
+|---|---|---|
+| `audroles.charDescription` | `text` | `text` |
+| `auditionsimport.charDescription` | `text` | `text` |
+| `noteslog_tbl.noteDetails` | `text` | `text` |
+| `contactitems_tbl.valuetext` | `text` | `text` |
+
+**Implication:** the original "column too small / truncated at 100/250/2000 chars" root cause behind tickets **2161** and **2187** is already resolved at the schema level in BOTH environments. Any remaining truncation is code-level (and, per investigation, already removed from the code too).
+
+`taoversions` verid 46 = `2.1.1 beta`, versionstatus `Pending`.
+
+Additional confirmed diagnostic: an audit of `pgapplinks` (the DB-driven CSS/JS link source used by `include/core.cfm`) found **zero** `http://` or protocol-relative URLs among active links — all external assets are `https`. This **rules out mixed-content** as the cause of ticket **1614** (iPhone blank screen).
+
+---
+
+## Execution waves
+
+**Wave 1 — Code fixes implementable and reasoning-verifiable this session**
+- 1636 — phone display overwrite bug (restores formatting) — **SHIPPED**
+- 2161 — XLSX header-row ingestion + edit-path category resolution — **SHIPPED**
+- 1780 — unified "All Sources" audition filter bar — **documented, not shipped** (capability-regression + product decision; see ticket)
+- 1839 — address CSV export — **documented, not shipped** (xlsx address export already exists; see ticket)
+
+> Shipping discipline: with no running app to browser-test against, I shipped only the fixes that are unambiguous bugs, safe by static reasoning, and mirror existing code patterns (1636, 2161). Candidates that carried UX-regression risk (1780), redundancy with existing features (1839), or needed artifacts/decisions I could not obtain were documented with exact build steps and a clear reason, rather than shipped blind.
+
+**Wave 2 — Verify-only (already fixed in dev code/DB; needs functional retest + prod deploy confirmation)**
+- 2132 — payrate saves independent of income type
+- 2187 — relationship-import notes no longer truncated
+- 2161 (bug #2) — imported note lands in Notes log, not logline
+- 1657 — calendar ICS UID stabilized (TAO-CAL-01)
+- 1463 — broken "Fix" button retired; replaced by V3 inline editor
+
+**Wave 3 — Scoped features / partial**
+- 1725 — Part A (contact/relationship merge) already built; Part B (company merge) is net-new
+- 1839 (full) — Avery-template PDF label rendering (net-new PDF engine)
+- 1636 (full) — full international (AU + 200-country) formatting
+
+**Wave 4 — Blocked / external / needs device**
+- 2143 — Google OAuth app verification (manual Google Cloud Console process)
+- 2015 — Google one-way sync verification (gated on 2143) + two-way sync (net-new)
+- 1614 — iPhone 14 Pro Max blank screen (needs on-device Safari Web Inspector)
+
+---
+
+## Cross-cutting themes
+
+1. **Prod-vs-dev build drift is the shared root of the "reverted from Implemented" tickets** (2132, 2161 bugs #2/#3, 2187). The dev-branch code is already correct; these most likely reproduced because production had not yet deployed the fix, or QA tested a cached/wrong screen. **First action for every verify-only ticket: confirm production runs current dev HEAD.**
+2. **Audition import pipeline** (2161, 1463, and 2187's audition path) all live in the V3 importer: `ajax/import-auditions/*`, `services/AuditionImportService.cfc`, `ajax/import-auditions/recompute.cfm`. The legacy `include/upload_audition*.cfm` and `include/get_record_data.cfm` are orphaned dead code — ticket hints pointing there are stale.
+3. **Note truncation + the V3_6 migration** underpins both 2161 (bug #2) and 2187. `noteslog_tbl.noteDetails` is confirmed `text`.
+4. **Google OAuth plumbing** is shared by 2143 and 2015; 2015's end-to-end verification is gated on 2143.
+5. **`contactitems` write surface** is shared by 1636 (phone display) and 1725 Part B (company normalize).
+
+## Global risks
+
+- **VIEW vs base table:** `contactitems` and `noteslog` are VIEWs over `_tbl` base tables — any DDL targets the `_tbl`.
+- **Implicit scope search is DISABLED** on the TAO CF server. Any refactor of a shared `cfinclude`'s leaked-variable contract will hard-error, not silently default. Phone-format changes (1636) keep the existing variable contract for exactly this reason.
+- **Autonomous-session limits:** several tickets need artifacts unavailable here — a live browser + real Google account (2015, 2143), a physical iPhone console (1614), and the reporter's actual failing spreadsheet + `import_auditions` log (2161 bug #1).
+- **Bulk/irreversible writes** (1725 company normalize, any import re-run) must be transactional and audited (reuse `contact_merge_log` / `contact_merge_map`).
+
+---
+
+# Per-ticket plan
+
+## Wave 1 — code fixes this session
+
+### Ticket 1636 — International phone number formatting
+- **Type/Priority:** Bug / Medium · **Est:** 6h (full) — bug fix portion ~0.5h
+- **Page:** contact display (`contact_pane.cfm`, `contact_view.cfm`, `contact_info.cfm`)
+- **Root cause (confirmed):** `include/formatPhoneNumber.cfm` computes a formatted number (lines 5–19) but then **lines 21–23 unconditionally overwrite** `formatPhoneNumber` and `anchorPhoneNumber` back to `cleanPhoneNumber` (digits only). Result: every phone in the app renders as bare digits and all the formatting logic is dead. This is leftover debug code.
+- **Fix (this session):** remove the overwrite so the computed US format survives; the `tel:` anchor uses digits (valid for `tel:`), display uses `(xxx) xxx-xxxx`. Preserves the existing two-variable contract (no scope-search hazard).
+- **Full feature (deferred, Wave 3):** per-country formatting (AU `xxxx-xxx-xxx`) requires a country→pattern map keyed off the contact's address country or `taousers` country, threaded into the 3 display includes. Needs a product decision (bundle `libphonenumber-js` vs a small CFML pattern map). `countries.csv` currently has no calling-code/pattern data.
+- **Acceptance:** a 10-digit US phone renders as `(213) 555-0134` on the contact detail/list/view; the `tel:` link still dials; non-10-digit numbers fall back to raw. No undefined-variable error on any page that includes the file.
+- **Status log:** _Wave-1 bug fix APPLIED (see Execution Log). Full i18n deferred._
+
+### Ticket 2161 — Audition spreadsheet import: Review & Fix issues
+- **Type/Priority:** Bug (Tested - Bug) / Medium · **Est:** 2.5h
+- **Page:** V3 audition importer (`ajax/import-auditions/*`, `services/AuditionImportService.cfc`)
+- **Sub-issues and disposition:**
+  - **Bug #2 (note mapped to logline + truncated):** ALREADY FIXED. Finalize writes the note to the audition Notes log via `NoteService.INSnoteslog_23966` and leaves `projDescription` NULL (`AuditionImportService.cfc:1674-1676, 1777-1787`); `recompute.cfm:841-847` preserves full text; `noteDetails` is `text`. → verify-only.
+  - **Bug #3 (Category "film" not recognized):** FIXED at import/parse time — `recompute.cfm:937-959` calls `resolveCategoryToSubCatId()` which matches case-insensitively (`LOWER(...)`). **Residual code gap:** the review-grid **edit** path `updateRowFields` case `"category"` (`AuditionImportService.cfc:1187-1189`) only stores the typed text and never resolves it to an `audsubcatid` fact, so typing a category *name* in the edit modal still trips the `missingCategory` required-check (1250-1259). → **fix_now.**
+  - **Bug #1 (single-record import shows no data on Review & Fix):** root cause not provable from static code. Strong candidate: `parse.cfm:311` reads XLSX with `cfspreadsheet ... headerrow="1"` **without** `excludeHeaderRow`, so the header row is ingested as a data row (the CSV branch explicitly skips it via `<cfloop from="2">`). This is an inconsistency and a real defect. → apply `excludeHeaderRow="true"` as a **candidate fix_now**; confirm against the reporter's actual file + `import_auditions` log.
+- **Fixes (this session):**
+  1. `parse.cfm`: add `excludeHeaderRow="true"` to the XLSX read so header is not a phantom data row (matches CSV behavior).
+  2. `AuditionImportService.cfc` edit path: in `updateRowFields` case `"category"`, resolve text → `audsubcatid` via `resolveCategoryToSubCatId()` and upsert the `audsubcatid` fact (mirror of `recompute.cfm:944-955`), wrapped in `cftry`.
+- **Acceptance:** single-data-row XLSX lands on Review & Fix with exactly one populated row (no phantom header row); multi-row still shows all rows; typing `film`/`Film` in the edit modal clears "Audition category is required"; a >255-char note imports intact into the Notes tab and `projDescription` is empty.
+- **Blocker:** bug #1 final confirmation needs the reporter's spreadsheet + server log.
+- **Status log:** _Wave-1 fixes APPLIED (header-row + edit-path category). Bug #1 pending artifact confirmation; bug #2 verify-only._
+
+### Ticket 1780 — Filter auditions by agent/team ("All Sources" bar)
+- **Type/Priority:** Bug (feature) / Medium · **Est:** 3h · **Page:** `auditions.cfm` (`/app/auditions/`)
+- **Root cause:** not a defect — a requested unified filter. The list already has two separate dropdowns: "All Reps" (`sel_repid` → `audroles.contactid`) and "All Submission Sources" (`sel_sourceid` → `audroles.submitsiteid`), both feeding `AuditionProjectService.getAuditions`. The ask is ONE "All Sources" bar whose options = team members + sources.
+- **Fix (this session):** add a combined `optgroup` select ("Team Members" / "Sources"), route the single selection to the existing `sel_repid`/`sel_sourceid` filters (values prefixed `team:` / `src:`). No SQL change; reuses existing parameterized filters. Thread the new param through the export/view-toggle/pagination URLs.
+- **Acceptance:** selecting a team member filters by that rep; selecting a source filters by that source; Reset clears it; pagination and export preserve the selection.
+- **Scope note:** true multi-select OR (several sources + teams at once) is a larger change (new arg + parenthesized OR SQL in `getAuditions`) — confirm with PM before building. Duplicate group with #1263/#2180.
+- **Status log:** _DOCUMENTED — not shipped this session. The page ALREADY filters independently by rep ("All Reps") AND by source ("All Submission Sources"). Collapsing them into one mutually-exclusive bar is a **capability regression** (you can no longer filter by rep AND source together) and hinges on a product decision (replace the two filters, or add a third combined search?). Shipping an unverifiable UX change to a core list page was judged higher-risk than the value. Ready-to-build steps are recorded above; needs a PM decision + browser test._
+
+### Ticket 1839 — Print mailing labels from relationship addresses
+- **Type/Priority:** Bug (feature) / Medium · **Est:** 6h (full); MVP ~1.5h · **Page:** `contacts.cfm`
+- **Root cause:** net-new feature. The contacts list already has an Export button that POSTs selected `idlist` to `include/exportContacts.cfm` (which already emits an .xlsx containing the mailing address via `ContactItemService.SELcontactitems_23896`). A clean CSV-download pattern exists at `share/export.cfm:59-67`. No `cfdocument`/`cfhtmltopdf` exists anywhere, so Avery PDF rendering is entirely net-new.
+- **Fix (this session, MVP):** add `include/exportLabelsCsv.cfm` (modeled on `share/export.cfm`) that takes `idlist`, pulls each contact's address, and streams a mail-merge-ready CSV (`FirstName,LastName,Company,Address,Address2,City,State,Zip,Country`); add an "Export Labels (CSV)" option to the existing export modal.
+- **Full feature (deferred, Wave 3):** Avery 5160/5161/5162 format select + `cfdocument`-based PDF grid (first PDF usage in the app — verify the CF PDF engine is enabled on the server) + physical-sheet alignment check.
+- **Acceptance:** selecting contacts and choosing "Export Labels (CSV)" downloads a CSV with one row per selected contact that has an address, columns in mail-merge order, quotes escaped; contacts without an address are skipped.
+- **Status log:** _DOCUMENTED — not shipped this session. Investigation showed `include/exportContacts.cfm` ALREADY exports an .xlsx containing every mailing-address column (Address/Address2/City/State/Zip/Country) via a staging pipeline, and Word/Google Docs mail-merge accepts .xlsx directly — so the MVP "get my addresses out for labels" need is effectively already met today. Adding a parallel CSV endpoint would duplicate that staging pipeline (untestable in this session) for marginal gain. The genuine remaining gap is Avery-template **PDF** rendering (no `cfdocument`/`cfhtmltopdf` anywhere; needs a server PDF-engine check) — a Wave-3 build. Ready-to-build steps recorded above._
+
+## Wave 2 — verify-only
+
+### Ticket 2132 — Payrate saves even without income type
+- **Type/Priority:** Bug (reverted from Implemented) / Medium · **Est:** 0.5h
+- **Root cause (traced):** NOT reproducible from current code. The project-details save (`AuditionProjectService.UPDaudprojects_24586`, `.cfc:108-141`) writes `payrate` whenever `len(trim(new_payrate))` — **independent** of income type; income type is a separate branch with a no-op fallback. The income-type `<select>` in the modal has no empty option and always pre-selects id=1 (`remote_aud_project_update.cfm:229-234`), and the param defaults to 1 — so income type can never be "unset". The alternate "I Booked It" booking save (`AuditionRoleService.UPDaudroles_23810`) also saves payrate independently. The fix commits (`3a48cfe0`, `de00a0a4`, 2026-01-18) are present in dev HEAD.
+- **Remaining work:** confirm production runs dev HEAD for `AuditionProjectService.cfc`; functionally retest the exact modal; confirm with the tester which modal they used (project-details vs booking).
+- **Acceptance:** in a deployed environment, entering only a payrate persists it: `SELECT payrate FROM audroles WHERE audprojectid=<id>` reflects the new value.
+- **Status log:** _Verify-only. Code confirmed correct in dev HEAD. Needs prod deploy check + functional retest (no running app in session)._
+
+### Ticket 2187 — Relationship import notes no longer truncated
+- **Type/Priority:** Modification (Implemented) / Medium · **Est:** 1h
+- **Root cause (traced):** the 4/29 "first note full, second truncated" symptom was DB-column truncation. Code truncation `LEFT(trim(...),2000)` was removed (`NoteService.cfc`, commit `fd698440`); the earlier V3_5 migration mistakenly altered the *view* (a no-op — see `noteslog` VIEW/`_tbl` note), so the base column stayed narrow until **V3_6** (`f60b0fb6`, 2026-06-21) widened `noteslog_tbl.noteDetails` to `text`. All relationship/contact import note paths (`ContactImportV2Service.addNote:1434`, `ContactImportV3Service:1638`, audition path `INSnoteslog_23966`) bind `cf_sql_longvarchar` with no cap. Confirmed `noteslog_tbl.noteDetails = text` in prod + dev.
+- **Remaining work:** functional retest importing a relationship CSV with two long notes (one <2000, one >2000 chars); confirm both stored full.
+- **Optional follow-up (separate ticket):** `NoteService.cfc:49` and `:310` (event-note paths, NOT import) still bind `cf_sql_varchar` — a latent inconsistency, out of scope for 2187.
+- **Status log:** _Verify-only. Code + DB confirmed fixed. Needs functional two-long-note retest._
+
+### Ticket 1657 — Calendar not syncing (nothing after October)
+- **Type/Priority:** Bug / Medium · **Est:** 1.5h
+- **Root cause (traced):** the `.ics` feed is independent of Google (no OAuth), a static file built from the `events` table with **no date cutoff** (filters only userid + non-null start/stop + active + not deleted). The "nothing after October" symptom was an **unstable UID**: legacy generators emitted a fresh `CreateUUID()` on every regen (`include/icsmaker.cfm:243`, `sched/icsmaker.cfm:243`), regenerated every 10 min + on every calendar view, so subscribers treated each poll as delete-all/recreate-all and froze on the last good snapshot. **TAO-CAL-01 already fixes this** — `IcsService.cfc:168` emits stable `tao-event-{eventID}@theactorsoffice.com`, wired via `EventService.fireIcsRegen` + nightly reconcile.
+- **Remaining work:** confirm prod runs TAO-CAL-01 (not legacy generators); confirm the 10-min task is disabled and the 3am reconcile is registered; regenerate all `.ics`; verify stable UID + a Nov/Dec event present; have the reporting user re-subscribe to clear their cached snapshot.
+- **Status log:** _Verify-only/deploy. Code fixed (TAO-CAL-01); independent of Google (do not block on 2143)._
+
+### Ticket 1463 — Import Auditions "Fix" button error
+- **Type/Priority:** Bug (reverted from Implemented) / Medium · **Est:** 1.5h
+- **Root cause (traced):** the "Error fetching record data." alert came from the OLD Fix-button flow (`loadForm()` → `GET /include/get_record_data.cfm` in a `#fixModal`). That button was commented out (`65b0f8f4`) and its JS removed (`f55b3fbd`). The page is now the V3 wizard; the error string exists nowhere in the current page or `audition-import.js`. The V3 Review & Fix step replaces it with an inline edit modal (`editRow()` → `GET /ajax/import-auditions/row.cfm`). The failing endpoint is retired.
+- **Remaining work:** functional test of the V3 inline editor (route residual editor defects to 2161); OPTIONAL: retire unreferenced dead files `include/get_record_data.cfm`, `include/fetch_updated_row.cfm`, `include/update_import_auditions.cfm` after a grep confirms no references.
+- **Status log:** _Verify-only (superseded). Broken path already removed; dead-code cleanup left as optional to keep the change reversible._
+
+## Wave 3 — scoped features / partial
+
+### Ticket 1725 — Merge duplicate relationships (and companies)
+- **Type/Priority:** Bug (feature) / Medium · **Est:** 12h+
+- **Root cause / disposition:** two asks. **(A) merge duplicate contacts/relationships is ALREADY fully built** — `services/ContactDuplicateService.cfc` `mergeContacts()` (189-472) repoints every linked child table inside one `cftransaction` with a full audit/undo map (`contact_merge_log` / `contact_merge_map`): `contactitems_tbl` incl. Company + Tag items, `noteslog_tbl`, `eventcontactsxref_tbl`, `audcontacts_auditions_xref`, `fusystemusers_tbl` (with WO-3.1 unique-index collision handling), `funotifications` (no-op via `suID`), `refer_contact_id`, then soft-delete. **(B) merge duplicate companies is net-new** — there is no companies entity; "company" is the free-text `contactitems.valuecompany` string.
+- **Plan:** Part A → verify-only (functional test of contact merge for a contact enrolled in a relationship system with reminders). Part B → net-new: `findDuplicateCompanies(userid)` (group `valueCategory='Company'` by normalized name), a "Companies" tab in `app/contact-duplicates/index.cfm` with a canonical-name picker, and a transactional normalize that reuses the existing merge audit/rollback pattern.
+- **Product decision needed:** confirm "companies" = normalizing free-text `valuecompany` strings.
+- **Status log:** _Part A verify-only (already built). Part B scoped, not built this session (needs product decision + multi-hour transactional build)._
+
+## Wave 4 — blocked / external / needs device
+
+### Ticket 2143 — Google has not verified the app
+- **Type/Priority:** Bug (external) / Medium · **Classification:** blocked_external
+- **Root cause:** not a code bug. The "unverified app" interstitial is Google's OAuth consent-screen/verification state. The app requests the Google-classified *sensitive* scope `https://www.googleapis.com/auth/calendar.events` (`include/calendarSectionCalendar.cfm:132`). Any app requesting a sensitive Calendar scope for external users must complete Google's OAuth brand + scope verification. Client id/secret/redirect come from `application.secrets` (`TAO_GOOGLE_OAUTH_CLIENT_ID/_SECRET/_REDIRECT_URI`).
+- **Manual resolution (human, Google Cloud Console — outside repo):**
+  1. In the project owning `TAO_GOOGLE_OAUTH_CLIENT_ID` → APIs & Services → OAuth consent screen; User type = External.
+  2. Complete branding: app name, support email, logo, developer contact, home page (`https://app.theactorsoffice.com`), **privacy policy URL + terms URL**.
+  3. Under Scopes add `calendar.events` (or the reduced `calendar.events.readonly` if only reading — see optional code step) with a scope justification.
+  4. Under Credentials, ensure Authorized redirect URIs include exactly `https://app.theactorsoffice.com/oauth/oauth_callback.cfm` (+ UAT/dev callbacks).
+  5. Submit for verification (brand + sensitive-scope review; can take days–weeks). Interim: add up to 100 Test users to bypass the warning.
+- **Optional code step:** the app only READS calendar data, so the scope can likely be reduced to `calendar.events.readonly`, which may ease verification.
+- **Status log:** _Blocked_external — documented manual steps + optional scope reduction. No code change closes this._
+
+### Ticket 2015 — Verify Google integration (one-way) / two-way
+- **Type/Priority:** Bug / Medium · **Classification:** blocked_external (+ large_feature for two-way)
+- **Root cause (traced):** (1) **Direction mismatch** — the only Google Calendar API call in the app is a READ/PULL: `ajax/google-calendar-events.cfm:30` GETs `calendar/v3/calendars/primary/events` and maps them into FullCalendar as read-only (`editable=false`). The implemented direction is Google→TAO, not TAO→Google. (2) **No push/write path exists** — repo-wide search for PUT/PATCH/DELETE/insertEvent and any `google_event_id`/`gcal_id` mapping column returns zero matches.
+- **Plan:** correct the ticket framing (what exists is a Google→TAO read-only pull); verify that pull end-to-end AFTER 2143 unblocks OAuth (needs a live browser + real Google account); exercise the token-refresh path. Two-way sync is net-new (push on appoint/audition create+update, conflict resolution, bidirectional mapping columns, recurring, timezones).
+- **Status log:** _Blocked on 2143 for verification; two-way sync scoped as separate large feature. Not actionable in a code-only session._
+
+### Ticket 1614 — Blank screen on iPhone 14 Pro Max
+- **Type/Priority:** Bug (Tested - Bug) / Medium · **Classification:** needs_device
+- **Root cause (static review + DB audit):** common iOS-Safari blockers are RULED OUT — no CSP (web.config only does dotfile-block + http→https redirect), no service worker/appcache/manifest, viewport meta present (`include/core.cfm:21`), modern Safari supports the shipped JS. **DB audit of `pgapplinks` found zero mixed-content (`http://`/`//`) links** — the leading data-dependent hypothesis is disproved. One page-scoped latent bug exists (`audition-import.js:1448` `new Date(dateStr)` is Safari-strict-invalid) but that is not a global blank screen.
+- **Remaining work (needs device):** attach the iPhone to Mac Safari Web Inspector (or BrowserStack live), load `/app/dashboard_new`, and read the console + network tab for the failing asset/JS error. Optional latent fix: parse `yyyy-mm-dd` manually before `new Date()` in `formatDateForInput`.
+- **Status log:** _needs_device — mixed-content ruled out via DB audit; no code cause found in static review. Requires on-device console._
+
+---
+
+## Execution log
+
+Working session 2026-07-02. Each ticket was either fixed (code change), verified (code/DB state confirmed, needs runtime retest), or noted-and-skipped (blocked/decision/needs-artifact) — per the "work each one, or note and move on" directive.
+
+### Code changes shipped this session
+
+| Ticket | File | Change |
+|---|---|---|
+| 1636 | `include/formatPhoneNumber.cfm` | Removed the trailing `formatphonenumber = cleanphonenumber` / `anchorPhoneNumber = cleanphonenumber` overwrite (old lines 21–23) that discarded all formatting. Phones now render `(xxx) xxx-xxxx` again; `tel:` anchor keeps digits. Variable contract unchanged (both vars still set in both branches — safe under disabled implicit scope search). |
+| 2161 | `ajax/import-auditions/parse.cfm` | Added `excludeHeaderRow="true"` to the XLSX `cfspreadsheet` read so the header is not ingested as a phantom data row (now consistent with the CSV branch, which loops from row 2). Candidate fix for bug #1 (single-record shows no/garbled data); confirm with reporter's file. |
+| 2161 | `services/AuditionImportService.cfc` (`updateRowFields`, `case "category"`) | When a user types a category NAME in the review-grid edit modal, resolve it to an `audsubcatid` via `resolveCategoryToSubCatId()` and upsert the `audsubcatid` fact (mirrors `recompute.cfm` import-time logic), guarded so it never overwrites an explicit dropdown selection. Clears the false "Audition category is required" flag. Fixes bug #3 residual. |
+
+### Per-ticket outcome
+
+- **1636 — FIXED (partial).** Shipped the overwrite-bug fix (restores US formatting everywhere). Full per-country (AU) formatting deferred to Wave 3 (needs country→pattern source + product decision).
+- **2161 — FIXED (bugs #1-candidate, #3) + VERIFY (bug #2).** Header-row and edit-path-category fixes shipped. Bug #2 (note→logline+truncation) already fixed in code/DB — needs functional retest. Bug #1 header-row fix is a strong candidate; final confirmation needs the reporter's failing spreadsheet + `import_auditions` log.
+- **2132 — VERIFY-ONLY.** Code fully traced: payrate already saves independent of income type on both save paths (fix committed 2026-01-18, present in dev HEAD). No code change. Needs prod deploy confirmation + functional retest; confirm which modal the tester used.
+- **2187 — VERIFY-ONLY.** Truncation removed from code + `noteslog_tbl.noteDetails` confirmed `text` in prod & dev (V3_6). No code change. Needs a two-long-note functional retest.
+- **1657 — VERIFY-ONLY (deploy).** ICS UID instability fixed by TAO-CAL-01 (stable `tao-event-{id}@...`); no date cutoff exists; feed is independent of Google. Needs prod-runs-TAO-CAL-01 confirmation, `.ics` regen, and a subscriber re-subscribe.
+- **1463 — VERIFY-ONLY (superseded).** The "Error fetching record data" path (old Fix button → `get_record_data.cfm`) is already removed; V3 inline editor replaces it. No code change; optional dead-code cleanup of 3 orphaned files left undone to keep the change reversible (route residual editor bugs to 2161).
+- **1780 — NOTED / not shipped.** Page already filters by rep AND source independently; collapsing to one bar is a capability regression + product decision. Ready-to-build steps recorded. Needs PM decision + browser test.
+- **1839 — NOTED / not shipped.** Address xlsx export already exists (Word can mail-merge from it); redundant CSV not added. Real gap = Avery PDF (Wave 3, needs PDF-engine check). Steps recorded.
+- **1725 — NOTED (Part A done, Part B scoped).** Contact/relationship merge already fully built with audit/undo (`ContactDuplicateService.mergeContacts`). Company merge is net-new; needs product confirmation that "company" = free-text `contactitems.valuecompany`. Not built this session.
+- **2143 — BLOCKED (external).** Google OAuth app verification — manual Google Cloud Console process documented above (+ optional scope reduction to `calendar.events.readonly`). No code closes it.
+- **2015 — BLOCKED (on 2143) + large.** Implemented direction is Google→TAO read-only pull, not TAO→Google; no push path exists. Verify after 2143; two-way sync is a scoped net-new feature.
+- **1614 — NEEDS DEVICE.** Static review + a live DB audit of `pgapplinks` (zero mixed-content links) rule out the common Safari blockers and the leading data hypothesis. Requires on-device Safari Web Inspector / BrowserStack to capture the failing asset/JS. Optional latent fix noted (`audition-import.js` `formatDateForInput`), but it already degrades gracefully and is not the blank-screen cause.
+
+### Suggested next steps for the team
+1. Deploy dev HEAD to production, then run the verify-only retests (2132, 2187, 2161 bug #2, 1657, 1463) — these likely reproduced only due to prod build drift.
+2. Obtain the reporter's failing single-record audition spreadsheet + `import_auditions` log to confirm 2161 bug #1 against the header-row fix.
+3. Make the two product decisions: 1780 (replace vs add filter bar) and 1725 Part B (company = valuecompany?).
+4. Start the Google Cloud Console verification for 2143 (unblocks 2015); it has a multi-week lead time.
+5. Book a device/BrowserStack session for 1614.

--- a/include/formatPhoneNumber.cfm
+++ b/include/formatPhoneNumber.cfm
@@ -13,11 +13,7 @@
 <cfelse>
     <cfoutput>
         <!--- If the phone number is not 10 digits, use the original phone number --->
-        <cfset formatPhoneNumber = "#phoneNumber#" /> 
-        <cfset anchorPhoneNumber = "#cleanPhoneNumber#" /> 
+        <cfset formatPhoneNumber = "#phoneNumber#" />
+        <cfset anchorPhoneNumber = "#cleanPhoneNumber#" />
     </cfoutput>
 </cfif>
-
-<!--- Set the formatted phone number variables for later use --->
-<cfset formatphonenumber = cleanphonenumber />
-<cfset anchorPhoneNumber = cleanphonenumber />

--- a/services/AuditionImportService.cfc
+++ b/services/AuditionImportService.cfc
@@ -1185,7 +1185,44 @@ component displayname="AuditionImportService" accessors="true" output="false" {
                         }
                         break;
                     case "category":
-                        // Category text is accepted - will attempt resolution at finalize time
+                        // Category text is accepted and also resolved to an audsubcatid
+                        // here so the review grid's required-category check clears when a
+                        // user types a category name in the edit modal (matches the
+                        // import-time resolution in ajax/import-auditions/recompute.cfm).
+                        // Skip if the row already has an explicit audsubcatid so a typed
+                        // name never clobbers a dropdown selection.
+                        if (len(normalizedVal)) {
+                            try {
+                                var qExplicitCat = queryExecute(
+                                    "SELECT normalized_value FROM import_auditions_facts
+                                     WHERE row_id = :row_id AND field_name = 'audsubcatid'
+                                       AND normalized_value IS NOT NULL AND normalized_value != '' AND normalized_value != '0'",
+                                    { row_id: { value: arguments.row_id, cfsqltype: "cf_sql_integer" } },
+                                    { datasource: application.datasource }
+                                );
+                                if (structKeyExists(request, "perfSvcQueryCount")) request.perfSvcQueryCount++;
+                                if (qExplicitCat.recordCount eq 0) {
+                                    var resolvedSubCatId = resolveCategoryToSubCatId(normalizedVal);
+                                    if (resolvedSubCatId gt 0) {
+                                        queryExecute(
+                                            "INSERT INTO import_auditions_facts (row_id, column_id, field_name, raw_value, normalized_value, is_valid, updated_at)
+                                             VALUES (:row_id, 0, 'audsubcatid', :val, :val, 1, NOW())
+                                             ON DUPLICATE KEY UPDATE
+                                                 normalized_value = :val, raw_value = :val, is_valid = 1,
+                                                 validation_code = NULL, validation_message = NULL, updated_at = NOW()",
+                                            {
+                                                row_id: { value: arguments.row_id, cfsqltype: "cf_sql_integer" },
+                                                val: { value: resolvedSubCatId, cfsqltype: "cf_sql_varchar" }
+                                            },
+                                            { datasource: application.datasource }
+                                        );
+                                        if (structKeyExists(request, "perfSvcQueryCount")) request.perfSvcQueryCount++;
+                                    }
+                                }
+                            } catch (any eCat) {
+                                // resolution failed; leave category as typed, required-check will flag it
+                            }
+                        }
                         break;
                     case "audsubcatid":
                         // Must be a valid "Other" subcategory ID


### PR DESCRIPTION
1636 - include/formatPhoneNumber.cfm: remove leftover overwrite that reset
  formatPhoneNumber/anchorPhoneNumber to raw digits, discarding all
  formatting. 10-digit numbers now render (xxx) xxx-xxxx again across
  contact_view, contact_pane, and contact_info.

2161 (#1) - ajax/import-auditions/parse.cfm: add excludeHeaderRow to the
  XLSX cfspreadsheet read so the header is not ingested as a phantom data
  row, matching the CSV branch which loops from row 2.

2161 (#3) - services/AuditionImportService.cfc: resolve typed category name
  to an audsubcatid in the review-grid edit modal (updateRowFields), so the
  required-category check clears. Guarded to never overwrite an explicit
  dropdown selection; resolution failure degrades gracefully.

Adds docs/plans/v2.1.1_verid46_ticket_plan.md (per-ticket plan + execution log for all 12 non-closed tickets) and v2.1.1_verid46_test_plan.md.